### PR TITLE
Support decoding custom refs and refs containing the sequence 00

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,13 +7,13 @@ var Service = require('./lib/service.js');
 
 var regex = {
     'git-receive-pack': RegExp('([0-9a-fA-F]+) ([0-9a-fA-F]+)'
-        + ' refs\/(heads|tags)\/(.*?)( |00|\u0000)'
+        + ' (refs\/[^ \u0000]+)( |00|\u0000)'
         + '|^(0000)$'
     ),
     'git-upload-pack': /^\S+ ([0-9a-fA-F]+)/
 };
 var fields = {
-    'git-receive-pack': [ 'last', 'head', 'ref', 'name' ],
+    'git-receive-pack': [ 'last', 'head', 'refname' ],
     'git-upload-pack': [ 'head' ]
 };
 

--- a/lib/service.js
+++ b/lib/service.js
@@ -18,14 +18,25 @@ function Service (opts, backend) {
     this._backend = backend;
     
     this.fields = {};
-    if (opts.name) this.fields.name = opts.name;
+
     if (opts.head) this.fields.head = opts.head;
     if (opts.last) this.fields.last = opts.last;
-    if (opts.ref) this.fields.ref = opts.ref;
-    
-    if (this.action === 'tag') this.fields.tag = opts.name;
-    else if (this.action === 'push') this.fields.branch = opts.name;
-    
+
+    if (opts.refname) {
+        this.fields.refname = opts.refname;
+
+        var refInfo = /^refs\/(heads|tags)\/(.*)$/.exec(opts.refname);
+
+        if (refInfo) {
+            this.fields.ref = refInfo[1];
+            this.fields.name = refInfo[2];
+
+            if (this.action === 'tag') this.fields.tag = this.fields.name;
+            else if (this.action === 'push') this.fields.branch = this.fields.name;
+        }
+    }
+
+
     this.args = [ '--stateless-rpc' ];
     if (this.info) this.args.push('--advertise-refs');
 }


### PR DESCRIPTION
There are two related issues being addressed here:
- The original pattern for receiving packs only matches branch and tag refs. You can push other refs though.
- The original pattern would truncate any ref name containing the character sequence `00` in its name because the `.*?` for matching everything after `heads|tags/` was non-greedy and `00` was one of the patterns after it. I couldn't find any reason why that 00 should be there, it seems to me that the ref name in this message is always terminated by space, null character, or EOF...never just 00 since 00 could be part of the ref name.

I suspect the `|00` should be removed, but left it there since I couldn't figure out how/why it ended up there. My new `[^ \u0000]+)` ahead of it should render it pointless though as that would consume any 00 sequence attached to the refname