### PR TITLE
Handle gzip-encoded requests in example

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -14,12 +14,14 @@ var http = require('http');
 var spawn = require('child_process').spawn;
 var path = require('path');
 var backend = require('git-http-backend');
+var zlib = require('zlib');
 
 var server = http.createServer(function (req, res) {
     var repo = req.url.split('/')[1];
     var dir = path.join(__dirname, 'repos', repo);
+    var reqStream = req.headers['content-encoding'] == 'gzip' ? req.pipe(zlib.createGunzip()) : req;
     
-    req.pipe(backend(req.url, function (err, service) {
+    reqStream.pipe(backend(req.url, function (err, service) {
         if (err) return res.end(err + '\n');
         
         res.setHeader('content-type', service.type);


### PR DESCRIPTION
I found git to sometimes gzip encode requests. `Backend.prototype._write` doesn't know what to make of it and doesn't have access to the headers of the request. The request body has to be piped through gunzip by the user's code it seems