### PR TITLE
use result content-type suffix for non-info requests

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -14,7 +14,8 @@ function Service (opts, backend) {
         'git-upload-pack': 'pull'
     }[this.cmd];
     
-    this.type = 'application/x-' + this.cmd + '-advertisement';
+    var typeExtension = this.info ? 'advertisement' : 'result';
+    this.type = 'application/x-' + this.cmd + '-' + typeExtension;
     this._backend = backend;
     
     this.fields = {};


### PR DESCRIPTION
if a request is not a GET request at `/info/refs`, append `-result` rather than `-advertisement` to the service's `type` property.

resolve issue [#16](https://github.com/substack/git-http-backend/issues/16)